### PR TITLE
Refactor: remove `newQR` overloads

### DIFF
--- a/src/QRgen.nim
+++ b/src/QRgen.nim
@@ -37,50 +37,8 @@ export
 
 proc newQR*(
   data: string,
-  mode: QRMode,
-  version: QRVersion,
-  ecLevel: QRECLevel = qrECL
+  ecLevel: QRECLevel = qrECL,
+  mode: QRMode = data.getMostEfficientMode,
+  version: QRVersion = data.getSmallestVersion(mode, ecLevel),
 ): DrawedQRCode =
-  ## Create a new DrawedQRCode with the specified `mode`, `version` and
-  ## `ecLevel` (`qrECL` by default).
-  ##
-  ## .. note:: The mode is not checked so make sure to use the correct one.
-  ##    It's recommended to use another proc which sets the mode automatically
-  ##    unless you know what you are doing.
-  ##
-  ## .. note:: The data size is checked to see if it fits in the specified
-  ##    version and ecLevel.
-  newQRCode(data, mode, version, ecLevel).encode.draw
-
-proc newQR*(
-  data: string,
-  version: QRVersion,
-  ecLevel: QRECLevel = qrECL
-): DrawedQRCode =
-  ## Create a new DrawedQRCode with the specified `version` and `ecLevel`
-  ## (`qrECL` by default).
-  ##
-  ## .. note:: The data size is checked to see if it fits in the specified
-  ##    version and ecLevel.
-  newQRCode(data, version, ecLevel).encode.draw
-
-proc newQR*(
-  data: string,
-  mode: QRMode,
-  ecLevel: QRECLevel = qrECL
-): DrawedQRCode =
-  ## Create a new DrawedQRCode with the specified `mode` and `ecLevel`
-  ## (`qrECL` by default).
-  ##
-  ## .. note:: The mode is not checked so make sure to use the correct one.
-  ##    It's recommended to use another proc which sets the mode automatically
-  ##    unless you know what you are doing.
-  newQRCode(data, mode, ecLevel).encode.draw
-
-proc newQR*(
-  data: string,
-  ecLevel: QRECLevel = qrECL
-): DrawedQRCode =
-  ## Create a new DrawedQRCode with the specified `ecLevel`
-  ## (`qrECL` by default).
-  newQRCode(data, ecLevel).encode.draw
+  newQRCode(data, ecLevel, mode, version).encode.draw


### PR DESCRIPTION
It's just boilerplate making both the code and docs more messy.