### PR TITLE
Fix: SVG embed encoding quotes inside attribute

### DIFF
--- a/src/QRgen/private/DrawedQRCode/print.nim
+++ b/src/QRgen/private/DrawedQRCode/print.nim
@@ -124,7 +124,7 @@ func encodeSvgEmbed(result: var string, svgImg: string) =
     of '<': result.add "%3c"
     of '>': result.add "%3e"
     of '"': result.add '\''
-    of '\'': result.add "%27"
+    of '\'': result.add "%22"
     of '#': result.add "%23"
     of ',': result.add "%2c"
     of ';': result.add "%3b"


### PR DESCRIPTION
I already encountered this issue when trying to embed the generated QRgen logo from inkscape, where attributes like:

```svg
style="-inkscape-font-specification:'Iosevka, Heavy Italic Expanded'"
```

Would make the SVG embed not load.