### PR TITLE
Refactor: Faster ecc encoding

### DIFF
--- a/src/QRgen/private/BitArray.nim
+++ b/src/QRgen/private/BitArray.nim
@@ -105,6 +105,17 @@ template unsafeDelete*(self: var BitArray, pos: uint16) =
   ## .. warning:: This is unsafe since `pos` is not updated.
   self.data.delete pos
 
+template unsafeSet*(
+  self: var BitArray,
+  pos: uint16 | BackwardsIndex,
+  val: uint8
+) =
+  ## Sets the value from `data` in position `pos` to `val`.
+  ##
+  ## .. warning:: This is unsafe since you may be setting the value of bits
+  ##    not yet reached by `pos`, which would then be overwritten.
+  self.data[pos] = val
+
 template len*(self: BitArray): int =
   ## Get the len of `self.data`.
   ## Used nstead of writing `data.data.len` in other modules.

--- a/src/QRgen/private/EncodedQRCode/encodeECCodewords.nim
+++ b/src/QRgen/private/EncodedQRCode/encodeECCodewords.nim
@@ -50,7 +50,15 @@ proc encodeECCodewords*(self: var EncodedQRCode) =
       let actualEcPos: uint16 =
         positions[^1] + (blockECCodewords[self].uint16 * i)
       let factor = self.data[j] xor self.data[actualEcPos]
-      self.data.unsafeDelete actualEcPos
-      self.data.unsafeAdd 0
+      when not defined(js):
+        moveMem(
+         self.data[actualECPos].addr,
+         self.data[actualEcPos+1].addr,
+         cast[uint16](self.data.len) - actualEcPos - 1'u8
+        )
+        self.data.unsafeSet ^1, 0'u8
+      else:
+        self.data.unsafeDelete actualEcPos
+        self.data.unsafeAdd 0
       for k in 0'u8..<degree:
         self.data[actualEcPos+k] ^= (gf256Mod285Multiply(generator[k], factor))


### PR DESCRIPTION
In `c` backend it's roughly 2.4 times faster.

But it's not much of a speed up, since it's 7.whatever ms vs 3.whatever ms in the test where the ECC generation is tested in all QR versions.