### PR TITLE
Fix: better rect and separation forcing

### DIFF
--- a/src/QRgen/private/DrawedQRCode/print.nim
+++ b/src/QRgen/private/DrawedQRCode/print.nim
@@ -141,9 +141,9 @@ func printSvg*(
   alRad: Percentage = 0,
   moRad: Percentage = 0,
   moSep: Percentage = 25,
+  forceUseRect: bool = false,
   class: string = "qrCode",
   id: string = "",
-  forceUseRect: bool = false,
   svgImg: string = "",
   svgImgCoords: tuple[x, y, w, h: uint8] = self.genDefaultCoords
 ): string =

--- a/src/QRgen/private/DrawedQRCode/print.nim
+++ b/src/QRgen/private/DrawedQRCode/print.nim
@@ -141,7 +141,7 @@ func printSvg*(
   alRad: Percentage = 0,
   moRad: Percentage = 0,
   moSep: Percentage = 25,
-  forceUseRect: bool = false,
+  forceSep: bool = false,
   class: string = "qrCode",
   id: string = "",
   svgImg: string = "",
@@ -165,7 +165,7 @@ func printSvg*(
   ##    roundness is set `0`, those will be drawed in a `<path>` and the
   ##    alignment patterns with a `<rect>`; if both are not `0` then both will
   ##    be drawed using `<rect>`. If you want to draw both with `<rect>` even
-  ##    if they have roundness set to `0`, you need to set `forceUseRect` to
+  ##    if they have roundness set to `0`, you need to set `forceSep` to
   ##    `true`.
   ##
   ## .. note:: Modules drawed as a rect have a separation from each other
@@ -201,7 +201,7 @@ func printSvg*(
     drawRegion 7'u8, size-7, 0'u8, 7'u8, s
     drawRegion 7'u8, size, size-7, size, s
   let moSepPx: float32 = 0.4 * moSep / 100
-  if moRad > 0 or forceUseRect:
+  if moRad > 0 or forceSep:
     let moRadPx: float32 = (0.5 - moSepPx) * moRad / 100
     result.add fmt(moRectGroupStart)
     drawQRModulesOnly moRect
@@ -213,7 +213,7 @@ func printSvg*(
     else:
       drawRegion 0'u8, size, 0'u8, size, moPath
     result.add fmt(moPathEnd)
-  if alRad > 0 or moRad > 0 or forceUseRect:
+  if alRad > 0 or moRad > 0 or forceSep:
     let alRadPx: float32 = 3.5 * alRad / 100
     template innerRadius(lvl: static range[0'i8..2'i8]): float32 =
       when lvl == 0: alRadPx

--- a/src/QRgen/renderer.nim
+++ b/src/QRgen/renderer.nim
@@ -46,6 +46,7 @@ proc renderImg*(
   alRad: Percentage = 0,
   moRad: Percentage = 0,
   moSep: Percentage = 25,
+  forceSep: bool = false,
   pixels: uint32 = 512,
   img: Image = Image(width: 0, height: 0),
   imgCoords: tuple[x, y, w, h: uint8] = self.genDefaultCoords
@@ -102,7 +103,7 @@ proc renderImg*(
     drawRegion 0'u8, size, 7'u8, size-7, f
     drawRegion 7'u8, size-7, 0'u8, 7'u8, f
     drawRegion 7'u8, size, size-7, size, f
-  if moRad > 0:
+  if moRad > 0 or forceSep:
     let
       moSepPx: float32 = modulePixels.float32 * 0.4 * moSep / 100
       s: Vec2 = vec2(
@@ -118,11 +119,11 @@ proc renderImg*(
         modulePixels.float32,
         modulePixels.float32
       )
-    if alRad > 0:
+    if alRad > 0 or forceSep:
       drawQRModulesOnly ctx.fillRect(rect(pos, s))
     else:
       drawRegion 0'u8, size, 0'u8, size, ctx.fillRect(rect(pos, s))
-  if alRad > 0 or moRad > 0:
+  if alRad > 0 or moRad > 0 or forceSep:
     let alRadPx: float32 = 3.5 * alRad / 100
     template innerRadius(lvl: static range[0'i8..2'i8]): float32 =
       when lvl == 0: alRadPx

--- a/src/QRgen/renderer.nim
+++ b/src/QRgen/renderer.nim
@@ -3,7 +3,7 @@
 ## This module contains a QR renderer using pixie, which can be used to render
 ## QR's into PNG images (and any format pixie supports) with an almost equal
 ## API to `printSvg` (some parameter names vary, you can specify the size in
-## pixels of the resulting image and there is no `forceUseRect`).
+## pixels of the resulting image).
 ## You can find pixie `here<https://github.com/treeform/pixie>`_.
 ##
 ## As said, this module requires the pixie nimble package, and it's also not
@@ -69,6 +69,9 @@ proc renderImg*(
   ##    and `100` (inclusive) which determines the separation, `0` being no
   ##    separation and `100` making the modules minuscule. By default it is
   ##    `25` (0.1 separation on a 1 width module, making it have 0.8 width).
+  ##
+  ## .. note:: Separation will only work when `moRad` is not 0, if you want
+  ##    to force it set `forceSep` to `true`.
   ##
   ## .. note:: You can embed an `Image` in the generated QR code, as a logo for
   ##    example, by passinng it to `img`.

--- a/src/QRgen/renderer.nim
+++ b/src/QRgen/renderer.nim
@@ -119,7 +119,7 @@ proc renderImg*(
         modulePixels.float32,
         modulePixels.float32
       )
-    if alRad > 0 or forceSep:
+    if alRad > 0:
       drawQRModulesOnly ctx.fillRect(rect(pos, s))
     else:
       drawRegion 0'u8, size, 0'u8, size, ctx.fillRect(rect(pos, s))

--- a/tests/testQRGen.nim
+++ b/tests/testQRGen.nim
@@ -98,6 +98,16 @@ benchmarkTest "Testing separation":
       moSep = 100
     )
   )
+  writeFile(
+    "build" / "testingSeparation6.svg",
+    qr.printSvg(
+      "#1d2021", "#98971a",
+      alRad = 0,
+      moRad = 0,
+      moSep = 0,
+      forceUseRect = true
+    )
+  )
 
 benchmarkTest "Testing svg insertion":
   let qr = newQR("https://github.com/aruZeta/QRgen", ecLevel = qrECH)

--- a/tests/testQRGen.nim
+++ b/tests/testQRGen.nim
@@ -58,7 +58,7 @@ benchmarkTest "Testing separation":
       "#1d2021", "#98971a",
       alRad = 100,
       moRad = 0,
-      forceUseRect = true,
+      forceSep = true,
       moSep = 12.5
     )
   )
@@ -105,7 +105,7 @@ benchmarkTest "Testing separation":
       alRad = 0,
       moRad = 0,
       moSep = 0,
-      forceUseRect = true
+      forceSep = true
     )
   )
 

--- a/tests/testRenderer.nim
+++ b/tests/testRenderer.nim
@@ -43,7 +43,7 @@ benchmarkTest "Testing rounded modules":
 benchmarkTest "Testing very rounded png":
   let qr = newQR("https://github.com/aruZeta/QRgen")
   writeFile(
-    qr.renderImg("#1d2021", "#98971a", alRad = 100, moRad = 100),
+    qr.renderImg("#1d2021", "#98971a", 100, 100),
     "build" / "testingVeryRoundedPng.png"
   )
 
@@ -54,7 +54,7 @@ benchmarkTest "Testing separation":
     "build" / "testingSeparationPng.png"
   )
   writeFile(
-    qr.renderImg("#282828", "#98971a", 0, 0, 50, true),
+    qr.renderImg("#1d2021", "#98971a", moSep = 50, forceSep = true),
     "build" / "testingSeparationPng2.png"
   )
 
@@ -63,7 +63,7 @@ benchmarkTest "Testing image embedding":
   writeFile(
     qr.renderImg(
       "#1d2021", "#fabd2f",
-      alRad = 100, moRad = 100,
+      100, 100,
       img = readImage("tests" / "testPngInsert.png")
     ),
     "build" / "testingPngInsertion.png"

--- a/tests/testRenderer.nim
+++ b/tests/testRenderer.nim
@@ -53,6 +53,10 @@ benchmarkTest "Testing separation":
     qr.renderImg("#1d2021", "#98971a", moRad = 100, moSep = 50),
     "build" / "testingSeparationPng.png"
   )
+  writeFile(
+    qr.renderImg("#282828", "#98971a", 0, 0, 50, true),
+    "build" / "testingSeparationPng2.png"
+  )
 
 benchmarkTest "Testing image embedding":
   let qr = newQR("https://github.com/aruZeta/QRgen", ecLevel = qrECH)


### PR DESCRIPTION
Adding separation forcing to `renderImg` and better API to set the forcing in both `renderImg` and `printSvg`.

Also renaming `forceUseRect` to `forceSep`, so both `renderImg` and `printSvg` APIs are equivalent.